### PR TITLE
Force vectorizer attributes to be copied from inputs, switch to consistent use of lists for label_names, terms

### DIFF
--- a/thecannon/censoring.py
+++ b/thecannon/censoring.py
@@ -35,7 +35,7 @@ class Censors(dict):
 
     def __init__(self, label_names, num_pixels, items=None, **kwargs):
         super(Censors, self).__init__(**kwargs)
-        self._label_names = tuple(label_names)
+        self._label_names = list(label_names)
         self._num_pixels = int(num_pixels)
         self.update(items or {})
         return None

--- a/thecannon/tests/test_censoring.py
+++ b/thecannon/tests/test_censoring.py
@@ -25,7 +25,7 @@ def test_censors_init(label_names, num_pixels):
     cn = Censors(label_names, num_pixels, items=dummy_items)
 
     # Check that everything has been set correctly
-    assert cn._label_names == label_names
+    assert cn._label_names == list(label_names)
     assert cn._num_pixels == num_pixels
     assert cn.keys() == dummy_items.keys()
     for k in cn.keys():
@@ -33,14 +33,14 @@ def test_censors_init(label_names, num_pixels):
 
     # Check the __getstate__ return
     gs = cn.__getstate__()
-    assert gs["label_names"] == label_names
+    assert gs["label_names"] == list(label_names)
     assert gs["num_pixels"] == num_pixels
     assert gs["items"].keys() == dummy_items.keys()
     for k in gs["items"].keys():
         assert np.all(gs["items"][k] == dummy_items[k])
 
     # Check the property returns
-    assert cn.label_names == label_names
+    assert cn.label_names == list(label_names)
     assert cn.num_pixels == num_pixels
 
 

--- a/thecannon/vectorizer/base.py
+++ b/thecannon/vectorizer/base.py
@@ -9,9 +9,9 @@ from __future__ import division, print_function, absolute_import, unicode_litera
 
 __all__ = ["BaseVectorizer"]
 
-import copy
 import numpy as np
 from typing import Union
+import copy
 
 
 class BaseVectorizer(object):
@@ -132,14 +132,13 @@ class BaseVectorizer(object):
 
         # Don't check the powers in the terms, except to make sure that there's no power
         # 0 in there - that would be meaningless
-        # import pdb; pdb.set_trace()
         try:
             assert ~np.any(np.isclose(list(powers), 0))
         except AssertionError:
             raise ValueError("0th-power terms are not permitted.")
 
         # Make the settings
-        self._label_names = copy.deepcopy(label_names)
+        self._label_names = list(label_names)
         self._terms = copy.deepcopy(terms)
 
     @property

--- a/thecannon/vectorizer/base.py
+++ b/thecannon/vectorizer/base.py
@@ -9,6 +9,7 @@ from __future__ import division, print_function, absolute_import, unicode_litera
 
 __all__ = ["BaseVectorizer"]
 
+import copy
 import numpy as np
 from typing import Union
 
@@ -54,8 +55,6 @@ class BaseVectorizer(object):
         if terms is None:
             terms = []
         self.update_labels_terms(tuple(label_names), terms)
-        # self._terms = terms
-        # self._label_names = tuple(label_names)
         self.metadata = kwargs.get("metadata", {})
         return None
 
@@ -95,7 +94,6 @@ class BaseVectorizer(object):
     def update_labels_terms(
         self, label_names: list[str], terms: list[list[tuple[Union[int, str], int]]]
     ) -> None:
-
         # Sanity-check the inputs
 
         # Ensure that all of the label references (name or index) are valid
@@ -141,8 +139,8 @@ class BaseVectorizer(object):
             raise ValueError("0th-power terms are not permitted.")
 
         # Make the settings
-        self._label_names = label_names
-        self._terms = terms
+        self._label_names = copy.deepcopy(label_names)
+        self._terms = copy.deepcopy(terms)
 
     @property
     def terms(self):


### PR DESCRIPTION
Fixing up the vectorizer `label_names` and `terms` values via `list()` or `deepcopy()` was straightforward.

Doing this revealed another issue, that Vectorizers and Censors were inconsistent in whether they use lists or tuples for storing `label_names` and `terms`. Everything has been consolidated onto using lists.