### PR TITLE
Implement multiple version testing on GitHub

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,8 +9,9 @@ jobs:
         py-version:  ["3.10", 3.11, 3.12]
         np-version:  ["2.0", 2.1, 2.2]
         sp-version:  [1.13, 1.14, 1.15]
+        runner: [macos-13, macos-latest, ubuntu-latest]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.runner}}
 
     steps:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,9 @@
-name: test_unittests
+name: CI
 
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  test_unittests_success:
+  unittests:
     strategy:
       matrix:
         py-version:  ["3.10", 3.11, 3.12]

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -6,7 +6,7 @@ jobs:
   test_model_output_defaults:
     strategy:
       matrix:
-        py-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        py-version:  [3.10, 3.11, 3.12, 3.13]
         np-version:  [2.0, 2.1, 2.2]
         sp-version:  [1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15]
 

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -9,8 +9,9 @@ jobs:
         py-version:  ["3.10", 3.11, 3.12]
         np-version:  ["2.0", 2.1, 2.2]
         sp-version:  [1.13, 1.14, 1.15]
+        runner: [macos-13, macos-latest, ubuntu-latest]
 
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.runner}}
 
     steps:
 

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         py-version:  ["3.10", 3.11, 3.12, 3.13]
         np-version:  ["2.0", 2.1, 2.2]
-        sp-version:  [1.9, "1.10", 1.11, 1.12, 1.13, 1.14, 1.15]
+        sp-version:  [1.13, 1.14, 1.15]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -6,9 +6,9 @@ jobs:
   test_model_output_defaults:
     strategy:
       matrix:
-        py-version:  [3.10, 3.11, 3.12, 3.13]
-        np-version:  [2.0, 2.1, 2.2]
-        sp-version:  [1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15]
+        py-version:  ["3.10", 3.11, 3.12, 3.13]
+        np-version:  ["2.0", 2.1, 2.2]
+        sp-version:  [1.9, "1.10", 1.11, 1.12, 1.13, 1.14, 1.15]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -6,7 +6,7 @@ jobs:
   test_model_output_defaults:
     strategy:
       matrix:
-        py-version:  ["3.10", 3.11, 3.12, 3.13]
+        py-version:  ["3.10", 3.11, 3.12]
         np-version:  ["2.0", 2.1, 2.2]
         sp-version:  [1.13, 1.14, 1.15]
 

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -4,6 +4,12 @@ on: push
 
 jobs:
   test_model_output_defaults:
+    strategy:
+      matrix:
+        py-version: [3.9, 3.10, 3.11, 3.12, 3.13]
+        np-version:  [2.0, 2.1, 2.2]
+        sp-version:  [1.9, 1.10, 1.11, 1.12, 1.13, 1.14, 1.15]
+
     runs-on: ubuntu-latest
 
     steps:
@@ -11,17 +17,16 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up test Python
+    - name: Set up test Python ${{matrix.py-version}}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9.20'
+        python-version: '~=${{matrix.py-version}}.0'
 
-    - name: Install dependencies
+    - name: Install dependencies (NumPy ${{matrix.np-version}}, SciPy ${{matrix.sp-version}})
       run: |
-        pip install pandas==2.0.3
-        pip install numpy==1.22.1
-        pip install scipy==1.7.3
-        pip install six==1.16.0
+        pip install numpy~=${{matrix.np-version}}.0
+        pip install scipy~=${{matrix.sp-version}}.0
+        pip install pandas
         pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.ref_name }}
 
     - name: Run run_cannon_andy_svens_python.py

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -3,7 +3,7 @@ name: test_model_output
 on: pull_request
 
 jobs:
-  test_model_output_defaults:
+  test_model_output_regression:
     strategy:
       matrix:
         py-version:  ["3.10", 3.11, 3.12]

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -28,7 +28,7 @@ jobs:
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
         pip install pytest
-        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.head_ref }}
+        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.event.pull_request.head.ref }}
 
     - name: Run run_cannon_andy_svens_python.py
       run: |

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -28,7 +28,7 @@ jobs:
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
         pip install pytest
-        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.ref_name }}
+        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.head_ref }}
 
     - name: Run run_cannon_andy_svens_python.py
       run: |

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -28,7 +28,7 @@ jobs:
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
         pip install pytest
-        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.event.pull_request.head.ref }}
+        python -m pip install .
 
     - name: Run run_cannon_andy_svens_python.py
       run: |

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -1,6 +1,6 @@
 name: test_model_output
 
-on: pull_request
+on: [pull_request, workflow_dispatch]
 
 jobs:
   test_model_output_regression:

--- a/.github/workflows/test_model_output.yml
+++ b/.github/workflows/test_model_output.yml
@@ -27,7 +27,12 @@ jobs:
         pip install numpy~=${{matrix.np-version}}.0
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
+        pip install pytest
         pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.ref_name }}
+
+    - name: Run pytest
+      run: |
+        pytest ./thecannon/tests
 
     - name: Run run_cannon_andy_svens_python.py
       run: |

--- a/.github/workflows/test_unittests.yml
+++ b/.github/workflows/test_unittests.yml
@@ -1,6 +1,6 @@
 name: test_unittests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test_unittests_success:

--- a/.github/workflows/test_unittests.yml
+++ b/.github/workflows/test_unittests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
         pip install pytest pytest-cov
-        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.event.pull_request.head.ref }}
+        python -m pip install .
 
     - name: Run pytest
       run: |

--- a/.github/workflows/test_unittests.yml
+++ b/.github/workflows/test_unittests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
         pip install pytest pytest-cov
-        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.ref_name }}
+        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.head_ref }}
 
     - name: Run pytest
       run: |

--- a/.github/workflows/test_unittests.yml
+++ b/.github/workflows/test_unittests.yml
@@ -3,7 +3,7 @@ name: test_unittests
 on: [push, pull_request]
 
 jobs:
-  test_model_output_defaults:
+  test_unittests_success:
     strategy:
       matrix:
         py-version:  ["3.10", 3.11, 3.12]

--- a/.github/workflows/test_unittests.yml
+++ b/.github/workflows/test_unittests.yml
@@ -28,7 +28,7 @@ jobs:
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
         pip install pytest pytest-cov
-        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.head_ref }}
+        pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.event.pull_request.head.ref }}
 
     - name: Run pytest
       run: |

--- a/.github/workflows/test_unittests.yml
+++ b/.github/workflows/test_unittests.yml
@@ -1,6 +1,6 @@
-name: test_model_output
+name: test_unittests
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   test_model_output_defaults:
@@ -27,17 +27,9 @@ jobs:
         pip install numpy~=${{matrix.np-version}}.0
         pip install scipy~=${{matrix.sp-version}}.0
         pip install pandas
-        pip install pytest
+        pip install pytest pytest-cov
         pip install --no-deps git+https://github.com/${{ github.repository }}@${{ github.ref_name }}
 
-    - name: Run run_cannon_andy_svens_python.py
+    - name: Run pytest
       run: |
-        python ./thecannon/tests/actions/run_cannon_generate_test_model.py
-
-    - name: Compare the prospect models
-      run : |
-        python ./thecannon/tests/actions/compare_generated_prospect_models.py
-
-    - name: Compare the prospect restricted models
-      run : |
-        python ./thecannon/tests/actions/compare_generated_prospect_restricted_models.py
+        pytest --cov-report term-missing --cov=thecannon ./thecannon/tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "thecannon"
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 dependencies = [
     "numpy>=2.0",
-    "scipy",
+    "scipy>=1.13",
 ]
 authors = [{name="Andrew R. Casey"}, {name="David W. Hogg"}, {name="Melissa Ness"}, {name="Marc White"}]
 maintainers = [{name="Marc White", email="marc.white@anu.edu.au"}, ]
@@ -31,7 +31,8 @@ keywords = ["The Cannon", "spectroscopy"]
 
 [project.optional-dependencies]
 test = [
-    "pytest"
+    "pytest",
+    "pytest-cov",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Closes #16 .

This PR adds testing against all supported versions of Python, NumPy and SciPy to GitHub actions.

- Unit tests (CI) are triggered on every push;
- Regression tests (test_model_output) are triggered on every pull request;
- Both test types can be manually triggered from the Actions tab.

The requirements versions have also been updated, based on the restrictions discovered during implementation. In short:

- Python 3.9 is no longer supported (NumPy 2.0 requirement)
- SciPy < 1.13 is no longer supported (previous versions do not support NumPy < 2.0)
- Python 3.13 is yet to be supported by any version of SciPy.