### PR TITLE
Replace different optimize functions with `op.minimize`.

### DIFF
--- a/thecannon/model.py
+++ b/thecannon/model.py
@@ -858,7 +858,7 @@ class CannonModel(object):
         T = self.design_matrix.shape[1]
 
         logger.info(
-            "Training {0}-label {1} with {2} stars and {3} pixels/star".format(
+            "Training {0}-label {1} with {2} input spectra and {3} pixels/spectrum".format(
                 len(self.vectorizer.label_names), type(self).__name__, S, P
             )
         )

--- a/thecannon/tests/test_fitting.py
+++ b/thecannon/tests/test_fitting.py
@@ -328,14 +328,14 @@ def test__remove_forbidden_op_kwds_bad_method(bad_method):
     ],
 )
 def test__remove_forbidden_op_kwds(method, forbidden_kw):
-    kwg = {k: None for k in fitting.FITTING_ALLOWED_KEYS[method]}
+    kwg = {k: None for k in fitting.FITTING_ALLOWED_OPTS[method]}
     for k in forbidden_kw:
         kwg[k] = None
 
     fitting._remove_forbidden_op_kwds(method, kwg)
 
     assert set(kwg.keys()) == set(
-        fitting.FITTING_ALLOWED_KEYS[method]
+        fitting.FITTING_ALLOWED_OPTS[method]
     ), "Failed to remove all bad keys"
 
 


### PR DESCRIPTION
This PR will (eventually) replace all custom-method `scipy.optimize` minimization methods with the standard `scipy.optimize`.

This PR is being held in draft form to trigger the `test_model_output` workflow as the most effective way of testing the changes.